### PR TITLE
Fix lag spikes in camera prefab

### DIFF
--- a/Assets/Example Render Texture.renderTexture
+++ b/Assets/Example Render Texture.renderTexture
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Example Render Texture
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 5
+  m_Width: 256
+  m_Height: 256
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 94
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2

--- a/Assets/Example Render Texture.renderTexture.meta
+++ b/Assets/Example Render Texture.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 876afe912165003de993cf3e7eefaab9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Example Render Texture.mat
+++ b/Assets/Materials/Example Render Texture.mat
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-2278018875100374859
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Example Render Texture
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 8400000, guid: 876afe912165003de993cf3e7eefaab9, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 8400000, guid: 876afe912165003de993cf3e7eefaab9, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/Example Render Texture.mat.meta
+++ b/Assets/Materials/Example Render Texture.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6787fc855049e3cd187995cdc2132919
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ROS Camera.prefab
+++ b/Assets/Prefabs/ROS Camera.prefab
@@ -142,6 +142,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NodeName: CameraPublisherFrontCenter
-  TopicName: /camera_front_center
+  CameraName: front_center
   CameraPixelWidth: 800
   CameraPixelHeight: 600

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -262,6 +262,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
+      propertyPath: nodeName
+      value: camera_front_right
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
       propertyPath: TopicName
       value: /camera_front_right
       objectReference: {fileID: 0}
@@ -335,6 +340,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: ROS Camera, Front Right
       objectReference: {fileID: 0}
+    - target: {fileID: 8201157730410575406, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -364,7 +374,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &536864850
 Transform:
   m_ObjectHideFlags: 0
@@ -392,10 +402,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9fbc5d997d525f3ea9c2173653a6522f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NodeName: CameraPublisherFrontLeft
-  CameraName: front_left
-  CameraPixelWidth: 800
-  CameraPixelHeight: 600
+  nodeName: camera_front_left
+  cameraName: 
+  cameraPixelWidth: 800
+  cameraPixelHeight: 600
 --- !u!114 &536864852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -807,7 +817,17 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
+      propertyPath: nodeName
+      value: camera_front_center
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
       propertyPath: CameraName
+      value: front_center
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: cameraName
       value: front_center
       objectReference: {fileID: 0}
     - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -265,6 +265,16 @@ PrefabInstance:
       propertyPath: TopicName
       value: /camera_front_right
       objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: CameraName
+      value: front_right
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: TopicPrefix
+      value: /camera/front_right/
+      objectReference: {fileID: 0}
     - target: {fileID: 3004722648913154706, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -383,7 +393,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NodeName: CameraPublisherFrontLeft
-  TopicName: /camera_front_left
+  CameraName: front_left
   CameraPixelWidth: 800
   CameraPixelHeight: 600
 --- !u!114 &536864852
@@ -795,6 +805,16 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 558044793}
     m_Modifications:
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: CameraName
+      value: front_center
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
+      propertyPath: TopicPrefix
+      value: /camera/front_center/
+      objectReference: {fileID: 0}
     - target: {fileID: 3004722648913154706, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -277,6 +277,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
+      propertyPath: cameraName
+      value: front_right
+      objectReference: {fileID: 0}
+    - target: {fileID: 1830068632625348474, guid: d2f26ca743f1e5966b64d384acd6603c,
+        type: 3}
       propertyPath: TopicPrefix
       value: /camera/front_right/
       objectReference: {fileID: 0}
@@ -343,7 +348,7 @@ PrefabInstance:
     - target: {fileID: 8201157730410575406, guid: d2f26ca743f1e5966b64d384acd6603c,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -374,7 +379,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &536864850
 Transform:
   m_ObjectHideFlags: 0
@@ -403,7 +408,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nodeName: camera_front_left
-  cameraName: 
+  cameraName: front_left
   cameraPixelWidth: 800
   cameraPixelHeight: 600
 --- !u!114 &536864852

--- a/Assets/Scripts/ROS/CameraPublisher.cs
+++ b/Assets/Scripts/ROS/CameraPublisher.cs
@@ -4,6 +4,8 @@ using System;
 using std_msgs.msg;
 using System.Linq;
 using System.Threading.Tasks;
+using Unity.Collections;
+using System.Security.Cryptography;
 
 namespace ROS2
 {
@@ -19,6 +21,9 @@ namespace ROS2
         public string cameraName;
         public int cameraPixelWidth = 800;
         public int cameraPixelHeight = 600;
+        private RenderTexture renderTexture;
+        Texture2D screenShot;
+        byte[] rawCameraData;
 
         private new Camera camera;
 
@@ -26,12 +31,67 @@ namespace ROS2
         {
             rosUnityComponent = GetComponentInParent<ROS2UnityComponent>();
             camera = GetComponent<Camera>();
+            renderTexture = new RenderTexture(cameraPixelWidth, cameraPixelHeight, 24);
 
+            // 4 bytes per pixel (RGBA)
+            rawCameraData = new byte[cameraPixelWidth * cameraPixelHeight * 4];
+
+            screenShot = new Texture2D(cameraPixelWidth, cameraPixelHeight, TextureFormat.RGBA32, false);
+            camera.targetTexture = renderTexture;
+        }
+
+        /// <summary>
+        /// SLOW conversion from NativeArray to byte[].
+        /// Likely slow due to GPU memory access, but that's just a theory.
+        /// </summary>
+        /// <param name="from">NativeArray with pixel data</param>
+        void PopulateBytesFromNativeArray(NativeArray<byte> from)
+        {
+            // var prev = Time.time;
+            for (int i = 0; i < from.Length; i++)
+            {
+                rawCameraData[i] = from[i];
+            }
+            // var elapsed = Time.time - prev;
+            // Debug.Log("Took "+elapsed);
         }
 
         void Update()
         {
-            
+
+            if (rosUnityComponent.Ok())
+            {
+                if (rosNode == null)
+                {
+                    // Set up the node and publisher.
+                    rosNode = rosUnityComponent.CreateNode(nodeName);
+                    imagePublisher = rosNode.CreatePublisher<sensor_msgs.msg.Image>("/camera/" + cameraName + "/image_color");
+                    cameraInfoPublisher = rosNode.CreatePublisher<sensor_msgs.msg.CameraInfo>("/camera/" + cameraName + "/camera_info");
+                }
+                sensor_msgs.msg.Image image_msg = new sensor_msgs.msg.Image();
+
+                image_msg.Data = rawCameraData;
+                image_msg.Encoding = "rgba8";
+                image_msg.Height = (uint)cameraPixelHeight;
+                image_msg.Width = (uint)cameraPixelWidth;
+                imagePublisher.Publish(image_msg);
+            }
+            camera.Render();
+
+            Rect rect = new Rect(0, 0, cameraPixelWidth, cameraPixelHeight);
+
+            RenderTexture.active = renderTexture;
+            screenShot.ReadPixels(rect, 0, 0);
+            RenderTexture.active = null;
+
+            // Graphics.CopyTexture(renderTexture, screenShot);
+
+            // byte[] imageData = screenShot.EncodeToPNG();
+            var pixels = screenShot.GetPixelData<byte>(0);
+            // Debug.Log(pixels.Length);
+            PopulateBytesFromNativeArray(pixels);
+            // byte[] imageData = screenShot.GetRawTextureData<byte>().ToArray();
+            // pixels = null;
         }
 
     }

--- a/Assets/Scripts/ROS/CameraPublisher.cs
+++ b/Assets/Scripts/ROS/CameraPublisher.cs
@@ -148,8 +148,14 @@ namespace ROS2
             camera.targetTexture = null;
             RenderTexture.active = null;
 
-            Destroy(renderTexture);
-            renderTexture = null;
+            // Destroy(renderTexture);
+
+            // DestroyImmediate(renderTexture);
+            // Texture2D[] textures = FindObjectsOfType<Texture2D>();
+            // foreach (Texture2D tx in textures)
+            // {
+            //     Destroy(tx);
+            // }
 
             // Reset this.
             GL.invertCulling = false;

--- a/Assets/Scripts/ROS/CameraPublisher.cs
+++ b/Assets/Scripts/ROS/CameraPublisher.cs
@@ -31,6 +31,11 @@ namespace ROS2
         {
             rosUnityComponent = GetComponentInParent<ROS2UnityComponent>();
             camera = GetComponent<Camera>();
+
+            // Fix flipped camera (ROS has different vertical axis than Unity)
+            Matrix4x4 scale = Matrix4x4.Scale (new Vector3 (1, -1, 1));
+            camera.projectionMatrix *= scale;
+
             renderTexture = new RenderTexture(cameraPixelWidth, cameraPixelHeight, 24);
 
             // 4 bytes per pixel (RGBA)
@@ -58,7 +63,6 @@ namespace ROS2
 
         void Update()
         {
-
             if (rosUnityComponent.Ok())
             {
                 if (rosNode == null)
@@ -76,7 +80,9 @@ namespace ROS2
                 image_msg.Width = (uint)cameraPixelWidth;
                 imagePublisher.Publish(image_msg);
             }
+            GL.invertCulling = true;
             camera.Render();
+            GL.invertCulling = false;
 
             Rect rect = new Rect(0, 0, cameraPixelWidth, cameraPixelHeight);
 
@@ -92,6 +98,7 @@ namespace ROS2
             PopulateBytesFromNativeArray(pixels);
             // byte[] imageData = screenShot.GetRawTextureData<byte>().ToArray();
             // pixels = null;
+
         }
 
     }

--- a/Assets/Scripts/ROS/CameraPublisher.cs
+++ b/Assets/Scripts/ROS/CameraPublisher.cs
@@ -10,158 +10,30 @@ namespace ROS2
     public class CameraPublisher : MonoBehaviour
     {
         // Start is called before the first frame update
-        private ROS2UnityComponent ros2Unity;
-        private ROS2Node ros2Node;
-        private IPublisher<sensor_msgs.msg.Image> image_pub;
-        private IPublisher<sensor_msgs.msg.CameraInfo> info_pub;
+        private ROS2UnityComponent rosUnityComponent;
+        private ROS2Node rosNode;
+        private IPublisher<sensor_msgs.msg.Image> imagePublisher;
+        private IPublisher<sensor_msgs.msg.CameraInfo> cameraInfoPublisher;
 
-        public string NodeName;
-        public string CameraName;
-        public uint CameraPixelWidth = 800;
-        public uint CameraPixelHeight = 600;
+        public string nodeName;
+        public string cameraName;
+        public int cameraPixelWidth = 800;
+        public int cameraPixelHeight = 600;
 
         private new Camera camera;
 
         void Start()
         {
-            ros2Unity = GetComponentInParent<ROS2UnityComponent>();
+            rosUnityComponent = GetComponentInParent<ROS2UnityComponent>();
             camera = GetComponent<Camera>();
 
-            // We want to handle rendering manually.
-            // By disabling the camera like this,
-            // we prevent Unity from rendering to the screen.
-            camera.enabled = false;
-
-
-            // Flip the axis: ROS assumes an image origin at the top left.
-            // In Unity, the origin is bottom left.
-            Matrix4x4 scale = Matrix4x4.Scale (new Vector3 (1, -1, 1));
-
-            // camera.targetTexture = renderTexture;
-            camera.projectionMatrix *= scale;
         }
 
         void Update()
         {
-            if (ros2Unity.Ok())
-            {
-                if (ros2Node == null)
-                {
-                    // Set up the node and publisher.
-                    ros2Node = ros2Unity.CreateNode(NodeName);
-                    image_pub = ros2Node.CreatePublisher<sensor_msgs.msg.Image>("/camera/" + CameraName + "/image_color");
-                    info_pub = ros2Node.CreatePublisher<sensor_msgs.msg.CameraInfo>("/camera/" + CameraName + "/camera_info");
-                }
-
-                Texture2D tex = GetCameraImage();
-                
-                // Encode the texture in JPG format
-                // byte[] bytes = ImageConversion.EncodeToJPG(tex);
-                UnityEngine.Object.Destroy(tex);
-
-                // Debug.Log(tex.GetPixelData<byte>(0).Length);
-
-                // Publish Image to ROS
-                sensor_msgs.msg.Image image_msg = new sensor_msgs.msg.Image();
-                byte[] image_data = tex.GetPixelData<byte>(0).ToArray();
-                image_msg.Data = image_data;
-                image_msg.Encoding = "rgba8";
-                image_msg.Height = CameraPixelHeight;
-                image_msg.Width = CameraPixelWidth;
-                image_pub.Publish(image_msg);
-
-                // Now public CameraInfo
-                sensor_msgs.msg.CameraInfo info_msg = GetCameraInfo();
-                info_pub.Publish(info_msg);
-
-                // Write the returned byte array to a file in the project folder
-                // File.WriteAllBytes($"/home/main/{NodeName}.jpg", bytes);
-            }
+            
         }
 
-        /// <summary>
-        /// Returns a Time object with the current game time.
-        /// </summary>
-        /// <returns>Time object with the current game time</returns>
-        builtin_interfaces.msg.Time GetStamp() {
-            builtin_interfaces.msg.Time stamp = new builtin_interfaces.msg.Time();
-
-            int sec = (int) Math.Floor(Time.time);
-
-            uint nanosec = (uint) ((Time.time - sec) * 1e9);
-
-            stamp.Sec = sec;
-            stamp.Nanosec = nanosec;
-
-            return stamp;
-        }
-
-        /// <summary>
-        /// Generate a CameraInfo object and return it.
-        /// </summary>
-        /// <returns>CameraInfo object matching current camera properties</returns>
-        sensor_msgs.msg.CameraInfo GetCameraInfo() {
-            sensor_msgs.msg.CameraInfo info_msg = new sensor_msgs.msg.CameraInfo();
-            info_msg.Header.Frame_id = CameraName;
-            info_msg.Header.Stamp = GetStamp();
-
-            return info_msg;
-        }
-
-        Texture2D FlipTexture(Texture2D original){
-            Texture2D flipped = new Texture2D(original.width,original.height);
-         
-            int xN = original.width;
-            int yN = original.height;
-         
-         
-           for(int i=0;i<xN;i++){
-              for(int j=0;j<yN;j++){
-                  flipped.SetPixel(xN-i-1, j, original.GetPixel(i,j));
-              }
-           }
-            flipped.Apply();
-         
-            return flipped;
-        }
-
-        private Texture2D GetCameraImage()
-        {
-            // https://discussions.unity.com/t/mirror-flip-camera/56560/2
-            // Altering the projection matrix disturbs how normal vectors are calculated
-            // during rendering. Use this to reverse the disturbance.
-            GL.invertCulling = true;
-
-            int width = (int) CameraPixelWidth;
-            int height = (int) CameraPixelHeight;
-            Rect rect = new Rect(0, 0, width, height);
-            RenderTexture renderTexture = new RenderTexture(width, height, 24);
-            Texture2D screenShot = new Texture2D(width, height, TextureFormat.RGBA32, false);
-
-            // By setting targetTexture, we tell Unity to disable rendering to the screen (in theory, at least)
-            camera.targetTexture = renderTexture;
-            camera.Render();
-
-            RenderTexture.active = renderTexture;
-            screenShot.ReadPixels(rect, 0, 0);
-
-            camera.targetTexture = null;
-            RenderTexture.active = null;
-
-            // Destroy(renderTexture);
-
-            // DestroyImmediate(renderTexture);
-            // Texture2D[] textures = FindObjectsOfType<Texture2D>();
-            // foreach (Texture2D tx in textures)
-            // {
-            //     Destroy(tx);
-            // }
-
-            // Reset this.
-            GL.invertCulling = false;
-
-            return screenShot;
-        }
     }
 
 }  // namespace ROS2

--- a/Assets/Scripts/ROS/CameraPublisherOld.txt
+++ b/Assets/Scripts/ROS/CameraPublisherOld.txt
@@ -1,0 +1,167 @@
+using UnityEngine;
+using System.IO;
+using System;
+using std_msgs.msg;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ROS2
+{
+    public class CameraPublisher : MonoBehaviour
+    {
+        // Start is called before the first frame update
+        private ROS2UnityComponent ros2Unity;
+        private ROS2Node ros2Node;
+        private IPublisher<sensor_msgs.msg.Image> image_pub;
+        private IPublisher<sensor_msgs.msg.CameraInfo> info_pub;
+
+        public string NodeName;
+        public string CameraName;
+        public uint CameraPixelWidth = 800;
+        public uint CameraPixelHeight = 600;
+
+        private new Camera camera;
+
+        void Start()
+        {
+            ros2Unity = GetComponentInParent<ROS2UnityComponent>();
+            camera = GetComponent<Camera>();
+
+            // We want to handle rendering manually.
+            // By disabling the camera like this,
+            // we prevent Unity from rendering to the screen.
+            camera.enabled = false;
+
+
+            // Flip the axis: ROS assumes an image origin at the top left.
+            // In Unity, the origin is bottom left.
+            Matrix4x4 scale = Matrix4x4.Scale (new Vector3 (1, -1, 1));
+
+            // camera.targetTexture = renderTexture;
+            camera.projectionMatrix *= scale;
+        }
+
+        void Update()
+        {
+            if (ros2Unity.Ok())
+            {
+                if (ros2Node == null)
+                {
+                    // Set up the node and publisher.
+                    ros2Node = ros2Unity.CreateNode(NodeName);
+                    image_pub = ros2Node.CreatePublisher<sensor_msgs.msg.Image>("/camera/" + CameraName + "/image_color");
+                    info_pub = ros2Node.CreatePublisher<sensor_msgs.msg.CameraInfo>("/camera/" + CameraName + "/camera_info");
+                }
+
+                Texture2D tex = GetCameraImage();
+                
+                // Encode the texture in JPG format
+                // byte[] bytes = ImageConversion.EncodeToJPG(tex);
+                UnityEngine.Object.Destroy(tex);
+
+                // Debug.Log(tex.GetPixelData<byte>(0).Length);
+
+                // Publish Image to ROS
+                sensor_msgs.msg.Image image_msg = new sensor_msgs.msg.Image();
+                byte[] image_data = tex.GetPixelData<byte>(0).ToArray();
+                image_msg.Data = image_data;
+                image_msg.Encoding = "rgba8";
+                image_msg.Height = CameraPixelHeight;
+                image_msg.Width = CameraPixelWidth;
+                image_pub.Publish(image_msg);
+
+                // Now public CameraInfo
+                sensor_msgs.msg.CameraInfo info_msg = GetCameraInfo();
+                info_pub.Publish(info_msg);
+
+                // Write the returned byte array to a file in the project folder
+                // File.WriteAllBytes($"/home/main/{NodeName}.jpg", bytes);
+            }
+        }
+
+        /// <summary>
+        /// Returns a Time object with the current game time.
+        /// </summary>
+        /// <returns>Time object with the current game time</returns>
+        builtin_interfaces.msg.Time GetStamp() {
+            builtin_interfaces.msg.Time stamp = new builtin_interfaces.msg.Time();
+
+            int sec = (int) Math.Floor(Time.time);
+
+            uint nanosec = (uint) ((Time.time - sec) * 1e9);
+
+            stamp.Sec = sec;
+            stamp.Nanosec = nanosec;
+
+            return stamp;
+        }
+
+        /// <summary>
+        /// Generate a CameraInfo object and return it.
+        /// </summary>
+        /// <returns>CameraInfo object matching current camera properties</returns>
+        sensor_msgs.msg.CameraInfo GetCameraInfo() {
+            sensor_msgs.msg.CameraInfo info_msg = new sensor_msgs.msg.CameraInfo();
+            info_msg.Header.Frame_id = CameraName;
+            info_msg.Header.Stamp = GetStamp();
+
+            return info_msg;
+        }
+
+        Texture2D FlipTexture(Texture2D original){
+            Texture2D flipped = new Texture2D(original.width,original.height);
+         
+            int xN = original.width;
+            int yN = original.height;
+         
+         
+           for(int i=0;i<xN;i++){
+              for(int j=0;j<yN;j++){
+                  flipped.SetPixel(xN-i-1, j, original.GetPixel(i,j));
+              }
+           }
+            flipped.Apply();
+         
+            return flipped;
+        }
+
+        private Texture2D GetCameraImage()
+        {
+            // https://discussions.unity.com/t/mirror-flip-camera/56560/2
+            // Altering the projection matrix disturbs how normal vectors are calculated
+            // during rendering. Use this to reverse the disturbance.
+            GL.invertCulling = true;
+
+            int width = (int) CameraPixelWidth;
+            int height = (int) CameraPixelHeight;
+            Rect rect = new Rect(0, 0, width, height);
+            RenderTexture renderTexture = new RenderTexture(width, height, 24);
+            Texture2D screenShot = new Texture2D(width, height, TextureFormat.RGBA32, false);
+
+            // By setting targetTexture, we tell Unity to disable rendering to the screen (in theory, at least)
+            camera.targetTexture = renderTexture;
+            camera.Render();
+
+            RenderTexture.active = renderTexture;
+            screenShot.ReadPixels(rect, 0, 0);
+
+            camera.targetTexture = null;
+            RenderTexture.active = null;
+
+            // Destroy(renderTexture);
+
+            // DestroyImmediate(renderTexture);
+            // Texture2D[] textures = FindObjectsOfType<Texture2D>();
+            // foreach (Texture2D tx in textures)
+            // {
+            //     Destroy(tx);
+            // }
+
+            // Reset this.
+            GL.invertCulling = false;
+
+            return screenShot;
+        }
+    }
+
+}  // namespace ROS2

--- a/Assets/Scripts/ROS/CameraPublisherOld.txt.meta
+++ b/Assets/Scripts/ROS/CameraPublisherOld.txt.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: debdabc9c73169cb196020136e0fb443
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.rider": "3.0.27",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.memoryprofiler": "1.1.0",
     "com.unity.render-pipelines.universal": "14.0.9",
     "com.unity.terrain-tools": "5.0.1",
     "com.unity.test-framework": "1.1.33",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -25,6 +25,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.editorcoroutines": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,
@@ -62,6 +69,15 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.memoryprofiler": {
+      "version": "1.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.editorcoroutines": "1.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -92,7 +92,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -103,7 +103,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
The lag spikes were due to excessive garbage collection in `Update()`. Specifically, the culprit was the conversion of pixel data from the Texture2D's NativeArray (`screenShot.GetPixelData<byte>(0);`). The standard NativeArray.ToArray() method allocated memory without releasing it properly.

My solution is not ideal: A very simple custom method that accesses each element in the NativeArray and populates a pre-allocated `byte[]` array elementwise:

```c#
    void PopulateBytesFromNativeArray(NativeArray<byte> from)
    {
        for (int i = 0; i < from.Length; i++)
        {
            rawCameraData[i] = from[i];
        }
    }
```

With 3 800x600px cameras, the FPS is now ~30 :grimacing: . But at least it's stable.